### PR TITLE
feat: redesign login page inspired by ghost admin

### DIFF
--- a/src/routes/auth/layout.tsx
+++ b/src/routes/auth/layout.tsx
@@ -1,11 +1,9 @@
-import { Link, Outlet } from 'react-router'
+import { Outlet } from 'react-router'
 
 import type { RouteHandle } from '@/root'
 
 import { useDetachPublicCss } from '@/client/hooks/use-detach-public-css'
 import { AdminErrorFallback } from '@/ui/admin/shell/AdminErrorFallback'
-import { useSiteIdentityOptional } from '@/ui/lib/blog-config-context'
-import { BrandLogo } from '@/ui/public/chrome/BrandLogo'
 // The login / install screen is admin chrome — same shadcn / Tailwind v4
 // cascade the admin SPA uses, so import `tailwind.css` directly. This
 // keeps the public-site Bootstrap cascade (`public.css`) and the
@@ -21,40 +19,16 @@ export const handle: RouteHandle = { layout: 'admin' }
 export { AdminErrorFallback as ErrorBoundary }
 
 export default function AdminLayoutRoute() {
-  // Defensive cleanup mirroring the admin SPA: when the user reaches
-  // this route via a client-side navigation from the public site, RR
-  // keeps the public `public.css` <link> attached to <head>. The
-  // un-layered Bootstrap reset would otherwise smother every shadcn
-  // primitive on this page (see hook docs for the full cascade story).
   useDetachPublicCss()
 
-  // The login / install split-screen sits IN FRONT of the install gate
-  // (the install page is the only way through the gate when the
-  // deployment hasn't been initialised yet), so the blog-config context
-  // can be `undefined` here — fall back to a hardcoded brand string so
-  // the chrome stays meaningful on a fresh deployment.
-  const siteIdentity = useSiteIdentityOptional()
-  const siteTitle = siteIdentity?.title ?? '且听书吟'
-
   return (
-    <div className="relative flex min-h-screen flex-col bg-background text-foreground">
-      {/* Soft brand-tinted backdrop. Pure CSS — no remote asset host
-          dependency, so the screen renders identically on a fresh
-          deployment that hasn't been installed yet. */}
+    <div className="relative flex min-h-screen items-center justify-center bg-background text-foreground">
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,var(--accent),transparent_55%),radial-gradient(circle_at_bottom_right,color-mix(in_oklab,var(--primary)_18%,transparent),transparent_60%)]"
       />
-      <header className="flex items-center justify-between px-6 py-5 lg:px-10 lg:py-7">
-        <Link to="/" title={siteTitle} prefetch="intent" className="flex items-center gap-3 text-foreground">
-          <BrandLogo alt={siteTitle} className="h-8 w-auto" />
-        </Link>
-        <span className="hidden text-sm text-muted-foreground sm:inline">{siteTitle} · 管理入口</span>
-      </header>
-      <main className="flex flex-1 items-start justify-center px-4 pt-8 sm:items-center sm:py-12">
-        <div className="w-full max-w-sm">
-          <Outlet />
-        </div>
+      <main className="w-full max-w-[500px] px-8 py-12">
+        <Outlet />
       </main>
     </div>
   )

--- a/src/routes/auth/layout.tsx
+++ b/src/routes/auth/layout.tsx
@@ -22,14 +22,12 @@ export default function AdminLayoutRoute() {
   useDetachPublicCss()
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center bg-background text-foreground">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,var(--accent),transparent_55%),radial-gradient(circle_at_bottom_right,color-mix(in_oklab,var(--primary)_18%,transparent),transparent_60%)]"
-      />
-      <main className="w-full max-w-[500px] px-8 py-12">
-        <Outlet />
-      </main>
+    <div className="flex min-h-screen flex-col bg-white text-foreground">
+      <div className="flex flex-1 flex-shrink-0 items-center justify-center px-[5%] pb-[8vh]">
+        <main className="w-full max-w-[500px] py-12">
+          <Outlet />
+        </main>
+      </div>
     </div>
   )
 }

--- a/src/routes/auth/signin.tsx
+++ b/src/routes/auth/signin.tsx
@@ -16,7 +16,8 @@ import { tryPasswordResetByEmailRateLimit, tryPasswordResetRateLimit } from '@/s
 import { bundleFromMatches, routeMeta } from '@/server/render/seo/meta'
 import { safeRedirectPath } from '@/shared/utils/safe-url'
 import { AdminCredentialsForm } from '@/ui/admin/auth/AdminCredentialsForm'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/components/card'
+import { useSiteIdentityOptional } from '@/ui/lib/blog-config-context'
+import { BrandLogo } from '@/ui/public/chrome/BrandLogo'
 
 import type { Route } from './+types/signin'
 
@@ -184,54 +185,50 @@ export function meta({ matches }: Route.MetaArgs) {
 }
 
 export default function LoginRoute({ actionData, loaderData }: Route.ComponentProps) {
+  const siteIdentity = useSiteIdentityOptional()
+  const siteTitle = siteIdentity?.title ?? ''
+
+  const description =
+    loaderData.action === 'lostpassword'
+      ? '输入邮箱以接收密码重置链接。'
+      : loaderData.action === 'resetpassword'
+        ? '设置新密码。'
+        : loaderData.action === 'accept-invite'
+          ? '设置登录密码以接受邀请。'
+          : '使用管理员邮箱与密码登陆后台。'
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-xl">用户登陆</CardTitle>
-        <CardDescription>
-          {loaderData.action === 'lostpassword'
-            ? '输入邮箱以接收密码重置链接。'
-            : loaderData.action === 'resetpassword'
-              ? '设置新密码。'
-              : loaderData.action === 'accept-invite'
-                ? '设置登录密码以接受邀请。'
-                : '使用管理员邮箱与密码登陆后台。'}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
-        {actionData?.error && (
-          <div
-            role="alert"
-            aria-live="polite"
-            className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-          >
-            {actionData.error}
-          </div>
-        )}
-        {(actionData as unknown as { message?: string })?.message && (
-          <div
-            role="status"
-            aria-live="polite"
-            className="rounded-md border border-green-500/20 bg-green-500/10 px-3 py-2 text-sm text-green-600"
-          >
-            {(actionData as unknown as { message?: string }).message}
-          </div>
-        )}
-        {loaderData.tokenError && (
-          <div
-            role="alert"
-            aria-live="polite"
-            className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-          >
-            {loaderData.tokenError}
-          </div>
-        )}
-        <AdminCredentialsForm
-          csrf={loaderData.csrf}
-          mode={loaderData.action as 'login' | 'lostpassword' | 'resetpassword' | 'accept-invite'}
-          resetToken={loaderData.resetToken ?? undefined}
-        />
-      </CardContent>
-    </Card>
+    <div className="flex flex-col items-center">
+      <header className="mb-10 flex flex-col items-center gap-5">
+        <BrandLogo alt={siteTitle} className="h-14 w-auto" />
+        <p className="text-center text-[15px] leading-relaxed text-muted-foreground">{description}</p>
+      </header>
+
+      <AdminCredentialsForm
+        csrf={loaderData.csrf}
+        mode={loaderData.action as 'login' | 'lostpassword' | 'resetpassword' | 'accept-invite'}
+        resetToken={loaderData.resetToken ?? undefined}
+      />
+
+      {(actionData?.error || (actionData as unknown as { message?: string })?.message || loaderData.tokenError) && (
+        <div className="mt-5 text-center text-sm">
+          {actionData?.error && (
+            <p role="alert" aria-live="polite" className="text-destructive">
+              {actionData.error}
+            </p>
+          )}
+          {(actionData as unknown as { message?: string })?.message && (
+            <p role="status" aria-live="polite" className="text-green-600 dark:text-green-400">
+              {(actionData as unknown as { message?: string }).message}
+            </p>
+          )}
+          {loaderData.tokenError && (
+            <p role="alert" aria-live="polite" className="text-destructive">
+              {loaderData.tokenError}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
   )
 }

--- a/src/routes/auth/signin.tsx
+++ b/src/routes/auth/signin.tsx
@@ -16,7 +16,6 @@ import { tryPasswordResetByEmailRateLimit, tryPasswordResetRateLimit } from '@/s
 import { bundleFromMatches, routeMeta } from '@/server/render/seo/meta'
 import { safeRedirectPath } from '@/shared/utils/safe-url'
 import { AdminCredentialsForm } from '@/ui/admin/auth/AdminCredentialsForm'
-import { useSiteIdentityOptional } from '@/ui/lib/blog-config-context'
 import { BrandLogo } from '@/ui/public/chrome/BrandLogo'
 
 import type { Route } from './+types/signin'
@@ -185,33 +184,12 @@ export function meta({ matches }: Route.MetaArgs) {
 }
 
 export default function LoginRoute({ actionData, loaderData }: Route.ComponentProps) {
-  const siteIdentity = useSiteIdentityOptional()
-  const siteTitle = siteIdentity?.title ?? ''
-
-  const description =
-    loaderData.action === 'lostpassword'
-      ? '输入邮箱以接收密码重置链接。'
-      : loaderData.action === 'resetpassword'
-        ? '设置新密码。'
-        : loaderData.action === 'accept-invite'
-          ? '设置登录密码以接受邀请。'
-          : '使用管理员邮箱与密码登陆后台。'
-
   return (
     <div className="flex flex-col items-center">
-      <header className="mb-10 flex flex-col items-center gap-5">
-        <BrandLogo alt={siteTitle} className="h-14 w-auto" />
-        <p className="text-center text-[15px] leading-relaxed text-muted-foreground">{description}</p>
-      </header>
-
-      <AdminCredentialsForm
-        csrf={loaderData.csrf}
-        mode={loaderData.action as 'login' | 'lostpassword' | 'resetpassword' | 'accept-invite'}
-        resetToken={loaderData.resetToken ?? undefined}
-      />
+      <BrandLogo alt="" className="mb-10 h-20 w-auto" />
 
       {(actionData?.error || (actionData as unknown as { message?: string })?.message || loaderData.tokenError) && (
-        <div className="mt-5 text-center text-sm">
+        <div className="mb-10 text-center text-sm">
           {actionData?.error && (
             <p role="alert" aria-live="polite" className="text-destructive">
               {actionData.error}
@@ -229,6 +207,12 @@ export default function LoginRoute({ actionData, loaderData }: Route.ComponentPr
           )}
         </div>
       )}
+
+      <AdminCredentialsForm
+        csrf={loaderData.csrf}
+        mode={loaderData.action as 'login' | 'lostpassword' | 'resetpassword' | 'accept-invite'}
+        resetToken={loaderData.resetToken ?? undefined}
+      />
     </div>
   )
 }

--- a/src/server/infra/env.ts
+++ b/src/server/infra/env.ts
@@ -2,30 +2,23 @@ import { createEnv } from '@t3-oss/env-core'
 import process from 'node:process'
 import { z } from 'zod'
 
-export const env = createEnv({
+const envConfig = {
   server: {
+    // Default configuration. Normally let it as it is.
     LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).optional(),
     HOST: z.string().min(1).default('0.0.0.0'),
     PORT: z.coerce.number().int().min(1).max(65535).default(4321),
 
+    // Database
     DATABASE_URL: z.url(),
     REDIS_URL: z.url(),
+
+    // Session cookie signing.
     SESSION_SECRET: z.string().min(1),
 
-    // Filesystem path to the MaxMind GeoLite2-City mmdb. Optional —
-    // when unset (or unreadable) the analytics ingestion pipeline
-    // (`@/server/domains/analytics/geoip`) returns null-only geo fields and
-    // every other column on `access_log` still populates. Lives in
-    // env (not the `setting` table) because it's a deploy-time file
-    // path tied to whatever volume mount ships the binary; rotating
-    // it never makes sense to do from an admin UI.
+    // Filesystem path to the MaxMind GeoLite2-City mmdb. Optional.
     MAXMIND_DB_PATH: z.string().min(1).optional(),
-
-    // When `true`, admin sessions' visits to the home page and post /
-    // page detail pages are written to `access_log` like any other
-    // visitor. Default `false` keeps the dashboard owner out of their
-    // own visitor metrics (matches the `bumpPageView` exemption on
-    // `metric.pv`). Flip to `true` on dev environments where you want
+    // Flip to `true` on dev environments where you want
     // to see your own visits land in the table during analytics work.
     ANALYTICS_TRACK_ADMIN: z
       .enum(['true', 'false'])
@@ -34,17 +27,27 @@ export const env = createEnv({
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,
-})
+}
 
-// Both the legacy `ZEABUR_MAIL_*` SMTP credentials and the original
-// `ASSET_HOST` / `ASSET_SCHEME` CDN env vars used to live here. They
-// have all been promoted to the DB-backed admin settings panel
-// (`/admin/settings/mail` and `/admin/settings/assets`) so an
-// editor can rotate keys, switch buckets, or change the public URL
-// without redeploying. The MDX compile pipeline no longer reads any
-// image config (the rehype plugin is gone — image metadata is now
-// resolved at SSR time against the `image` table), so there is no
-// build-time dependency on these values either.
+function loadEnv() {
+  try {
+    return createEnv(envConfig)
+  } catch {
+    console.error(
+      [
+        '请确认 .env 文件中已正确设置以下变量：',
+        '',
+        '    DATABASE_URL   — PostgreSQL 连接地址',
+        '    REDIS_URL      — Redis 连接地址',
+        '    SESSION_SECRET — 会话加密密钥',
+      ].join('\n'),
+    )
+    process.exit(1)
+  }
+}
+
+const env = loadEnv()
+
 export const {
   ANALYTICS_TRACK_ADMIN,
   DATABASE_URL,

--- a/src/ui/admin/auth/AdminCredentialsForm.tsx
+++ b/src/ui/admin/auth/AdminCredentialsForm.tsx
@@ -1,4 +1,4 @@
-import { Form, useNavigation } from 'react-router'
+import { Form, Link, useNavigation } from 'react-router'
 
 import { Button } from '@/ui/components/button'
 import { Input } from '@/ui/components/input'
@@ -6,17 +6,13 @@ import { Label } from '@/ui/components/label'
 
 export interface AdminCredentialsFormProps {
   action?: string
-  /** Anti-CSRF token issued by the loader. Submitted as `name="csrf"`. */
   csrf: string
   mode?: 'login' | 'lostpassword' | 'resetpassword' | 'accept-invite'
-  /**
-   * One-time token from the email link, passed to the loader through
-   * the URL. The form re-submits it as a separate `name="reset_token"`
-   * field — keeping CSRF and reset tokens on distinct names avoids the
-   * FormData collision the previous shape walked into.
-   */
   resetToken?: string
 }
+
+const inputClasses =
+  'h-[54px] rounded-lg border-0 bg-muted/50 px-4 text-[17px] placeholder:text-muted-foreground/50 focus-visible:bg-background focus-visible:ring-2 focus-visible:ring-primary/25 focus-visible:border-primary'
 
 export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken }: AdminCredentialsFormProps) {
   const navigation = useNavigation()
@@ -24,26 +20,48 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
 
   if (mode === 'lostpassword') {
     return (
-      <Form method="post" action={action} id="loginForm" className="flex flex-col gap-5">
+      <Form method="post" action={action} id="loginForm" className="flex flex-col gap-6">
         <input type="hidden" name="csrf" value={csrf} />
         <div className="flex flex-col gap-2">
-          <Label htmlFor="loginForm-email">邮箱</Label>
-          <Input id="loginForm-email" name="email" type="email" autoComplete="email" required disabled={isSubmitting} />
+          <Label htmlFor="loginForm-email" className="text-[13px] font-semibold">
+            邮箱
+          </Label>
+          <Input
+            id="loginForm-email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+            disabled={isSubmitting}
+            className={inputClasses}
+          />
         </div>
-        <Button type="submit" name="submit" disabled={isSubmitting} className="w-full">
+        <Button
+          type="submit"
+          name="submit"
+          disabled={isSubmitting}
+          className="h-[52px] rounded-lg bg-brand-dark text-[17px] font-normal text-white hover:opacity-90"
+        >
           {isSubmitting ? '发送中...' : '发送重置邮件'}
         </Button>
+        <p className="text-center text-[13px] text-muted-foreground">
+          <Link to="/admin/signin" className="transition-colors hover:text-foreground">
+            返回登陆
+          </Link>
+        </p>
       </Form>
     )
   }
 
   if (mode === 'resetpassword' || mode === 'accept-invite') {
     return (
-      <Form method="post" action={action} id="loginForm" className="flex flex-col gap-5">
+      <Form method="post" action={action} id="loginForm" className="flex flex-col gap-6">
         <input type="hidden" name="csrf" value={csrf} />
         <input type="hidden" name="reset_token" value={resetToken ?? ''} />
         <div className="flex flex-col gap-2">
-          <Label htmlFor="loginForm-password">新密码</Label>
+          <Label htmlFor="loginForm-password" className="text-[13px] font-semibold">
+            新密码
+          </Label>
           <Input
             id="loginForm-password"
             name="password"
@@ -52,9 +70,15 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
             required
             minLength={6}
             disabled={isSubmitting}
+            className={inputClasses}
           />
         </div>
-        <Button type="submit" name="submit" disabled={isSubmitting} className="w-full">
+        <Button
+          type="submit"
+          name="submit"
+          disabled={isSubmitting}
+          className="h-[52px] rounded-lg bg-brand-dark text-[17px] font-normal text-white hover:opacity-90"
+        >
           {isSubmitting ? '保存中...' : '设置密码'}
         </Button>
       </Form>
@@ -62,25 +86,51 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
   }
 
   return (
-    <Form method="post" action={action} id="loginForm" className="flex flex-col gap-5">
+    <Form method="post" action={action} id="loginForm" className="flex flex-col gap-6">
       <input type="hidden" name="csrf" value={csrf} />
       <div className="flex flex-col gap-2">
-        <Label htmlFor="loginForm-email">邮箱</Label>
-        <Input id="loginForm-email" name="email" type="email" autoComplete="email" required disabled={isSubmitting} />
-      </div>
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="loginForm-password">密码</Label>
+        <Label htmlFor="loginForm-email" className="text-[13px] font-semibold">
+          邮箱
+        </Label>
         <Input
-          id="loginForm-password"
-          name="password"
-          type="password"
-          autoComplete="current-password"
+          id="loginForm-email"
+          name="email"
+          type="email"
+          autoComplete="email"
           required
-          minLength={10}
           disabled={isSubmitting}
+          className={inputClasses}
         />
       </div>
-      <Button type="submit" name="submit" disabled={isSubmitting} className="w-full">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="loginForm-password" className="text-[13px] font-semibold">
+          密码
+        </Label>
+        <div className="relative">
+          <Input
+            id="loginForm-password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            minLength={10}
+            disabled={isSubmitting}
+            className={`${inputClasses} pr-[5.5rem]`}
+          />
+          <Link
+            to="?action=lostpassword"
+            className="absolute top-[1px] right-[1px] bottom-[1px] flex items-center border-l border-muted px-4 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            忘记？
+          </Link>
+        </div>
+      </div>
+      <Button
+        type="submit"
+        name="submit"
+        disabled={isSubmitting}
+        className="h-[52px] rounded-lg bg-brand-dark text-[17px] font-normal text-white hover:opacity-90"
+      >
         {isSubmitting ? '登陆中...' : '登陆'}
       </Button>
     </Form>

--- a/src/ui/admin/auth/AdminCredentialsForm.tsx
+++ b/src/ui/admin/auth/AdminCredentialsForm.tsx
@@ -1,8 +1,10 @@
+import { ArrowRightIcon, SendIcon } from 'lucide-react'
 import { Form, Link, useNavigation } from 'react-router'
 
 import { Button } from '@/ui/components/button'
 import { Input } from '@/ui/components/input'
 import { Label } from '@/ui/components/label'
+import { cn } from '@/ui/lib/cn'
 
 export interface AdminCredentialsFormProps {
   action?: string
@@ -12,7 +14,7 @@ export interface AdminCredentialsFormProps {
 }
 
 const inputClasses =
-  'h-[54px] rounded-lg border-0 bg-muted/50 px-4 text-[17px] placeholder:text-muted-foreground/50 focus-visible:bg-background focus-visible:ring-2 focus-visible:ring-primary/25 focus-visible:border-primary'
+  'h-[54px] rounded-lg border-0 bg-muted/50 px-4 text-xl md:text-xl placeholder:text-muted-foreground/50 focus-visible:bg-background focus-visible:ring-2 focus-visible:ring-primary/25 focus-visible:border-primary'
 
 export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken }: AdminCredentialsFormProps) {
   const navigation = useNavigation()
@@ -20,10 +22,10 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
 
   if (mode === 'lostpassword') {
     return (
-      <Form method="post" action={action} id="loginForm" className="flex flex-col gap-6">
+      <Form method="post" action={action} id="loginForm" className="flex w-full flex-col gap-6">
         <input type="hidden" name="csrf" value={csrf} />
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="loginForm-email" className="text-[13px] font-semibold">
+        <div className="flex w-full flex-col gap-2">
+          <Label htmlFor="loginForm-email" className="text-[15px] font-semibold">
             邮箱
           </Label>
           <Input
@@ -31,6 +33,7 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
             name="email"
             type="email"
             autoComplete="email"
+            placeholder="your@email.com"
             required
             disabled={isSubmitting}
             className={inputClasses}
@@ -40,9 +43,15 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
           type="submit"
           name="submit"
           disabled={isSubmitting}
-          className="h-[52px] rounded-lg bg-brand-dark text-[17px] font-normal text-white hover:opacity-90"
+          className="mt-7 h-[52px] w-full rounded-lg bg-brand text-xl font-normal text-white hover:opacity-90"
         >
-          {isSubmitting ? '发送中...' : '发送重置邮件'}
+          {isSubmitting ? (
+            '发送中...'
+          ) : (
+            <>
+              发送重置邮件 <SendIcon className="ml-1 inline-block" size={18} />
+            </>
+          )}
         </Button>
         <p className="text-center text-[13px] text-muted-foreground">
           <Link to="/admin/signin" className="transition-colors hover:text-foreground">
@@ -55,11 +64,11 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
 
   if (mode === 'resetpassword' || mode === 'accept-invite') {
     return (
-      <Form method="post" action={action} id="loginForm" className="flex flex-col gap-6">
+      <Form method="post" action={action} id="loginForm" className="flex w-full flex-col gap-6">
         <input type="hidden" name="csrf" value={csrf} />
         <input type="hidden" name="reset_token" value={resetToken ?? ''} />
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="loginForm-password" className="text-[13px] font-semibold">
+        <div className="flex w-full flex-col gap-2">
+          <Label htmlFor="loginForm-password" className="text-[15px] font-semibold">
             新密码
           </Label>
           <Input
@@ -67,6 +76,7 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
             name="password"
             type="password"
             autoComplete="new-password"
+            placeholder="•••••••••••••••"
             required
             minLength={6}
             disabled={isSubmitting}
@@ -77,19 +87,25 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
           type="submit"
           name="submit"
           disabled={isSubmitting}
-          className="h-[52px] rounded-lg bg-brand-dark text-[17px] font-normal text-white hover:opacity-90"
+          className="mt-7 h-[52px] w-full rounded-lg bg-brand text-xl font-normal text-white hover:opacity-90"
         >
-          {isSubmitting ? '保存中...' : '设置密码'}
+          {isSubmitting ? (
+            '保存中...'
+          ) : (
+            <>
+              设置密码 <ArrowRightIcon className="ml-1 inline-block" size={18} />
+            </>
+          )}
         </Button>
       </Form>
     )
   }
 
   return (
-    <Form method="post" action={action} id="loginForm" className="flex flex-col gap-6">
+    <Form method="post" action={action} id="loginForm" className="flex w-full flex-col gap-6">
       <input type="hidden" name="csrf" value={csrf} />
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="loginForm-email" className="text-[13px] font-semibold">
+      <div className="flex w-full flex-col gap-2">
+        <Label htmlFor="loginForm-email" className="text-[15px] font-semibold">
           邮箱
         </Label>
         <Input
@@ -97,29 +113,31 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
           name="email"
           type="email"
           autoComplete="email"
+          placeholder="your@email.com"
           required
           disabled={isSubmitting}
           className={inputClasses}
         />
       </div>
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="loginForm-password" className="text-[13px] font-semibold">
+      <div className="flex w-full flex-col gap-2">
+        <Label htmlFor="loginForm-password" className="text-[15px] font-semibold">
           密码
         </Label>
-        <div className="relative">
+        <div className="relative w-full">
           <Input
             id="loginForm-password"
             name="password"
             type="password"
             autoComplete="current-password"
+            placeholder="•••••••••••••••"
             required
             minLength={10}
             disabled={isSubmitting}
-            className={`${inputClasses} pr-[5.5rem]`}
+            className={cn(inputClasses, 'pr-[5.5rem]')}
           />
           <Link
             to="?action=lostpassword"
-            className="absolute top-[1px] right-[1px] bottom-[1px] flex items-center border-l border-muted px-4 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+            className="absolute top-3 right-[1px] bottom-3 flex items-center border-l border-foreground/20 px-4 text-sm text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground"
           >
             忘记？
           </Link>
@@ -129,9 +147,15 @@ export function AdminCredentialsForm({ action, csrf, mode = 'login', resetToken 
         type="submit"
         name="submit"
         disabled={isSubmitting}
-        className="h-[52px] rounded-lg bg-brand-dark text-[17px] font-normal text-white hover:opacity-90"
+        className="mt-7 h-[52px] w-full rounded-lg bg-brand text-xl font-normal text-white hover:opacity-90"
       >
-        {isSubmitting ? '登陆中...' : '登陆'}
+        {isSubmitting ? (
+          '登陆中...'
+        ) : (
+          <>
+            登陆 <ArrowRightIcon className="ml-1 inline-block" size={18} />
+          </>
+        )}
       </Button>
     </Form>
   )


### PR DESCRIPTION
Redesign the login page to match Ghost Admin login style.

### Changes
- Switch to white background with Ghost-style centered layout
- Remove site title and description headers
- Enlarge brand logo and move alerts below it
- Use full-width forms and brand-colored buttons
- Increase input and button font sizes to match Ghost
- Add email and password placeholders
- Replace plain buttons with arrow/send icons
- Tighten vertical spacing between inputs and buttons
- Clear forgot divider line with darker border